### PR TITLE
chore: build tooling with npm scripts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Copy to .env and source it: `source .env`
+# Or add exports to ~/.bashrc for persistence
+
+# Bind preview server to all interfaces (e.g. for Tailscale access)
+# Default: 127.0.0.1 (localhost only)
+# PREVIEW_HOST=0.0.0.0

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.env
 dist
 dist-*
 cabal-dev

--- a/README.md
+++ b/README.md
@@ -1,26 +1,21 @@
 ## How to Build
 
-Requires `npm` (for `.ts`, `.scss`), `stack`, and `ghc`.'
+Requires `node`/`npm` and `stack`/`ghc`.
 
-1. Install node modules:
+1. Install dependencies + build haskell binary:
+   ```bash
+   npm run setup
    ```
-   npm install
+2. Generate the static site:
+   ```bash
+   npm run rebuild
    ```
-
-2. Build the Haskell executable:
+3. Preview locally (optional):
+   ```bash
+   npm run watch
    ```
-   stack build
-   ```
-3. Generate the static site:
-   ```
-   stack exec site rebuild
-   ```
-4. Preview locally (optional):
-   ```
-   stack exec site watch
-   ```
-5. Deploy to GitHub Pages:
-   ```
+4. Deploy to GitHub Pages:
+   ```bash
    git add -A
    git commit -m "publish."
    git push origin

--- a/package.json
+++ b/package.json
@@ -2,6 +2,12 @@
   "name": "magical-osu",
   "version": "0.1.0",
   "private": true,
+  "scripts": {
+    "setup": "npm install && stack build",
+    "build": "[ -f .env ] && . .env; stack exec site build",
+    "rebuild": "[ -f .env ] && . .env; stack exec site rebuild",
+    "watch": "[ -f .env ] && . .env; stack exec site watch"
+  },
   "dependencies": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/site.hs
+++ b/site.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+import System.Environment (lookupEnv)
 import System.FilePath ((</>))
 
 import Hakyll
@@ -29,7 +30,12 @@ escapeForAttr = concatMap escape
 --------------------------------------------------------------------------------
 
 main :: IO ()
-main = hakyllWith hakyllConfig $ do
+main = do
+    host <- lookupEnv "PREVIEW_HOST"
+    let cfg = case host of
+                Just h  -> hakyllConfig { previewHost = h }
+                Nothing -> hakyllConfig
+    hakyllWith cfg $ do
     match (makePattern templateDir "*") $ compile templateBodyCompiler
 
     match "static/**" $ do


### PR DESCRIPTION
## Summary

Adds npm scripts as a unified interface for build/dev commands, `.env` file support for local config overrides, and updates the README.

## Changes

- **`package.json`** — added `setup`, `build`, `rebuild`, `watch` scripts wrapping `stack` commands; all auto-source `.env` if present
- **`site.hs`** — reads `PREVIEW_HOST` env var to override preview server bind address (default: `127.0.0.1`)
- **`.env.example`** — documents available env vars; copy to `.env` to override locally
- **`.gitignore`** — added `.env`
- **`README.md`** — rewritten to use npm scripts; concise single-section format

## Testing

Manual — ran `npm run watch` with and without `.env` present.

## Related Issues

None