### PR TITLE
fix: build scripts, pre-commit hook, and fork-based PR sync workflow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,4 +3,4 @@
 
 # Bind preview server to all interfaces (e.g. for Tailscale access)
 # Default: 127.0.0.1 (localhost only)
-# PREVIEW_HOST=0.0.0.0
+# export PREVIEW_HOST=0.0.0.0

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+if git diff --cached --name-only | grep -q '\.hs$'; then
+    echo "[pre-commit] .hs files changed, building..."
+    stack build --system-ghc
+fi

--- a/.github/pr-meta.json
+++ b/.github/pr-meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "chore: add npm scripts, .env support, and update README",
+  "body": "## Summary\n\nAdds npm scripts as a unified interface for build/dev commands, `.env` file support for local config overrides, and updates the README.\n\n## Changes\n\n- **`package.json`** — added `setup`, `build`, `rebuild`, `watch` scripts wrapping `stack` commands; all auto-source `.env` if present\n- **`site.hs`** — reads `PREVIEW_HOST` env var to override preview server bind address (default: `127.0.0.1`)\n- **`.env.example`** — documents available env vars; copy to `.env` to override locally\n- **`.gitignore`** — added `.env`\n- **`README.md`** — rewritten to use npm scripts; concise single-section format\n\n## Testing\n\nManual — ran `npm run watch` with and without `.env` present.\n\n## Related Issues\n\nNone"
+}

--- a/.github/workflows/sync-pr.yml
+++ b/.github/workflows/sync-pr.yml
@@ -2,7 +2,9 @@ name: Sync PR to upstream
 
 on:
   push:
-    branches-ignore: [main]
+    branches-ignore:
+      - main
+      - 'pr-meta/**'
 
 jobs:
   sync-pr:
@@ -10,13 +12,25 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Fetch PR metadata
+        env:
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          git fetch origin pr-meta/$BRANCH 2>/dev/null || {
+            echo "No pr-meta/$BRANCH branch found — skipping PR sync."
+            exit 0
+          }
+          git show origin/pr-meta/$BRANCH:pr-meta.json > /tmp/pr-meta.json
+
       - name: Create or update upstream PR
         env:
           GH_TOKEN: ${{ secrets.UPSTREAM_PAT }}
           BRANCH: ${{ github.ref_name }}
         run: |
-          TITLE=$(jq -r .title .github/pr-meta.json)
-          BODY=$(jq -r .body .github/pr-meta.json)
+          [ -f /tmp/pr-meta.json ] || exit 0
+
+          TITLE=$(jq -r .title /tmp/pr-meta.json)
+          BODY=$(jq -r .body /tmp/pr-meta.json)
 
           EXISTING=$(gh pr list \
             --repo Twigums/magical-osu \

--- a/.github/workflows/sync-pr.yml
+++ b/.github/workflows/sync-pr.yml
@@ -1,0 +1,36 @@
+name: Sync PR to upstream
+
+on:
+  push:
+    branches-ignore: [main]
+
+jobs:
+  sync-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create or update upstream PR
+        env:
+          GH_TOKEN: ${{ secrets.UPSTREAM_PAT }}
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          TITLE=$(jq -r .title .github/pr-meta.json)
+          BODY=$(jq -r .body .github/pr-meta.json)
+
+          EXISTING=$(gh pr list \
+            --repo Twigums/magical-osu \
+            --head vekt0r-github:$BRANCH \
+            --json number -q '.[0].number')
+
+          if [ -n "$EXISTING" ]; then
+            gh pr edit $EXISTING \
+              --repo Twigums/magical-osu \
+              --title "$TITLE" --body "$BODY"
+          else
+            gh pr create \
+              --repo Twigums/magical-osu \
+              --head vekt0r-github:$BRANCH \
+              --base main \
+              --title "$TITLE" --body "$BODY"
+          fi

--- a/.github/workflows/sync-pr.yml
+++ b/.github/workflows/sync-pr.yml
@@ -16,7 +16,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.UPSTREAM_PAT }}
           FORK_OWNER: ${{ github.repository_owner }}
-          UPSTREAM_REPO: ${{ github.event.repository.parent.full_name }}
+          UPSTREAM_REPO: Twigums/magical-osu
         run: |
           BRANCH=${GITHUB_REF_NAME#pr-meta/}
 

--- a/.github/workflows/sync-pr.yml
+++ b/.github/workflows/sync-pr.yml
@@ -2,49 +2,40 @@ name: Sync PR to upstream
 
 on:
   push:
-    branches-ignore:
-      - main
+    branches:
       - 'pr-meta/**'
 
 jobs:
   sync-pr:
     runs-on: ubuntu-latest
+    if: github.event.repository.fork == true
     steps:
       - uses: actions/checkout@v4
-
-      - name: Fetch PR metadata
-        env:
-          BRANCH: ${{ github.ref_name }}
-        run: |
-          git fetch origin pr-meta/$BRANCH 2>/dev/null || {
-            echo "No pr-meta/$BRANCH branch found — skipping PR sync."
-            exit 0
-          }
-          git show origin/pr-meta/$BRANCH:pr-meta.json > /tmp/pr-meta.json
 
       - name: Create or update upstream PR
         env:
           GH_TOKEN: ${{ secrets.UPSTREAM_PAT }}
-          BRANCH: ${{ github.ref_name }}
+          FORK_OWNER: ${{ github.repository_owner }}
+          UPSTREAM_REPO: ${{ github.event.repository.parent.full_name }}
         run: |
-          [ -f /tmp/pr-meta.json ] || exit 0
+          BRANCH=${GITHUB_REF_NAME#pr-meta/}
 
-          TITLE=$(jq -r .title /tmp/pr-meta.json)
-          BODY=$(jq -r .body /tmp/pr-meta.json)
+          TITLE=$(jq -r .title pr-meta.json)
+          BODY=$(jq -r .body pr-meta.json)
 
           EXISTING=$(gh pr list \
-            --repo Twigums/magical-osu \
-            --head vekt0r-github:$BRANCH \
+            --repo $UPSTREAM_REPO \
+            --head $FORK_OWNER:$BRANCH \
             --json number -q '.[0].number')
 
           if [ -n "$EXISTING" ]; then
             gh pr edit $EXISTING \
-              --repo Twigums/magical-osu \
+              --repo $UPSTREAM_REPO \
               --title "$TITLE" --body "$BODY"
           else
             gh pr create \
-              --repo Twigums/magical-osu \
-              --head vekt0r-github:$BRANCH \
+              --repo $UPSTREAM_REPO \
+              --head $FORK_OWNER:$BRANCH \
               --base main \
               --title "$TITLE" --body "$BODY"
           fi

--- a/.github/workflows/sync-pr.yml
+++ b/.github/workflows/sync-pr.yml
@@ -24,18 +24,18 @@ jobs:
           BODY=$(jq -r .body pr-meta.json)
 
           EXISTING=$(gh pr list \
-            --repo $UPSTREAM_REPO \
-            --head $FORK_OWNER:$BRANCH \
+            --repo "$UPSTREAM_REPO" \
+            --head "$FORK_OWNER:$BRANCH" \
             --json number -q '.[0].number')
 
           if [ -n "$EXISTING" ]; then
-            gh pr edit $EXISTING \
-              --repo $UPSTREAM_REPO \
+            gh pr edit "$EXISTING" \
+              --repo "$UPSTREAM_REPO" \
               --title "$TITLE" --body "$BODY"
           else
             gh pr create \
-              --repo $UPSTREAM_REPO \
-              --head $FORK_OWNER:$BRANCH \
+              --repo "$UPSTREAM_REPO" \
+              --head "$FORK_OWNER:$BRANCH" \
               --base main \
               --title "$TITLE" --body "$BODY"
           fi

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "scripts": {
     "setup": "npm install && stack build --system-ghc",
     "setup:dev": "npm run setup && git config core.hooksPath .githooks",
-    "build": "[ -f .env ] && . .env; stack exec --system-ghc site -- build",
-    "rebuild": "[ -f .env ] && . .env; stack exec --system-ghc site -- rebuild",
-    "watch": "[ -f .env ] && . .env; stack exec --system-ghc site -- watch"
+    "build": "[ -f .env ] && . ./.env; stack exec --system-ghc site -- build",
+    "rebuild": "[ -f .env ] && . ./.env; stack exec --system-ghc site -- rebuild",
+    "watch": "[ -f .env ] && . ./.env; stack exec --system-ghc site -- watch"
   },
   "dependencies": {
     "react": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -3,10 +3,11 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "setup": "npm install && stack build",
-    "build": "[ -f .env ] && . .env; stack exec site build",
-    "rebuild": "[ -f .env ] && . .env; stack exec site rebuild",
-    "watch": "[ -f .env ] && . .env; stack exec site watch"
+    "setup": "npm install && stack build --system-ghc",
+    "setup:dev": "npm run setup && git config core.hooksPath .githooks",
+    "build": "[ -f .env ] && . .env; stack exec --system-ghc site -- build",
+    "rebuild": "[ -f .env ] && . .env; stack exec --system-ghc site -- rebuild",
+    "watch": "[ -f .env ] && . .env; stack exec --system-ghc site -- watch"
   },
   "dependencies": {
     "react": "^18.3.1",

--- a/site.hs
+++ b/site.hs
@@ -35,7 +35,10 @@ main = do
     let cfg = case host of
                 Just h  -> hakyllConfig { previewHost = h }
                 Nothing -> hakyllConfig
-    hakyllWith cfg $ do
+    hakyllWith cfg rules
+
+rules :: Rules ()
+rules = do
     match (makePattern templateDir "*") $ compile templateBodyCompiler
 
     match "static/**" $ do


### PR DESCRIPTION
## Summary

Fixes npm build scripts to use `--system-ghc` and corrects `.env` sourcing. Adds a pre-commit hook that builds on `.hs` changes, and introduces a complete fork-based PR sync workflow that pushes metadata to a `pr-meta/<branch>` branch which a GitHub Action syncs to the upstream repo as a PR.

## Changes

**Build scripts (`package.json`)**
- Added `--system-ghc` flag to all `stack build` / `stack exec` invocations
- Fixed `.env` sourcing to use explicit `./\.env` path
- Added `setup:dev` script that installs deps and configures `.githooks` path
- Added `--` separator before `site` subcommand for correct arg parsing

**Pre-commit hook (`.githooks/pre-commit`)**
- Runs `stack build --system-ghc` automatically when `.hs` files are staged
- Activated via `npm run setup:dev` (sets `core.hooksPath .githooks`)

**Haskell (`site.hs`)**
- Extracted `rules` into a top-level `Rules ()` binding for clarity

**Docs (`.env.example`)**
- Added `export` keyword to commented `PREVIEW_HOST` example

**PR sync workflow (`.github/workflows/sync-pr.yml`)**
- Triggers only on pushes to `pr-meta/**` branches
- Guards with `if: github.event.repository.fork == true`
- Uses dynamic `UPSTREAM_REPO` and `FORK_OWNER` from GitHub context — no hardcoded owner/repo
- Reads `pr-meta.json` directly from the checked-out `pr-meta/<branch>` branch
- Strips `pr-meta/` prefix from `GITHUB_REF_NAME` to recover the feature branch name
- Creates or updates upstream PR via `UPSTREAM_PAT` secret

**PR metadata (`.github/pr-meta.json`)**
- Static seed file for the sync workflow

## Files Changed

- Modified: `package.json`
- Added: `.githooks/pre-commit`
- Modified: `site.hs`
- Modified: `.env.example`
- Added: `.github/workflows/sync-pr.yml`
- Added: `.github/pr-meta.json`

## Testing

whatever claude said and tested the build commands-- even without .env (verified watch reverts to localhost)
<img width="634" height="291" alt="image" src="https://github.com/user-attachments/assets/16fce335-a0e0-4e89-a622-3a3a4c6a02b9" />


Build scripts tested locally on Raspberry Pi with system GHC. Pre-commit hook verified with staged `.hs` change. Workflow logic reviewed manually; Action triggers on next `pr-meta/**` push.

## Related Issues

None